### PR TITLE
Read M3U8 files

### DIFF
--- a/lib/m3uzi.rb
+++ b/lib/m3uzi.rb
@@ -32,44 +32,47 @@ class M3Uzi
   ## For now, reading m3u8 files is not keeping up to date with writing, so we're
   ## disabling it in this version.  (Possibly to be re-introduced in the future.)
   ##
-  # def self.read(path)
-  #   m3u = self.new
-  #   lines = ::File.readlines(path)
-  #   lines.each_with_index do |line, i|
-  #     case type(line)
-  #     when :tag
-  #       name, value = parse_general_tag(line)
-  #       m3u.add_tag do |tag|
-  #         tag.name = name
-  #         tag.value = value
-  #       end
-  #     when :info
-  #       duration, description = parse_file_tag(line)
-  #       m3u.add_file do |file|
-  #         file.path = lines[i+1].strip
-  #         file.duration = duration
-  #         file.description = description
-  #       end
-  #       m3u.final_media_file = false
-  #     when :stream
-  #       attributes = parse_stream_tag(line)
-  #       m3u.add_stream do |stream|
-  #         stream.path = lines[i+1].strip
-  #         attributes.each_pair do |k,v|
-  #           k = k.to_s.downcase.sub('-','_')
-  #           next unless [:bandwidth, :program_id, :codecs, :resolution].include?(k)
-  #           v = $1 if v.to_s =~ /^"(.*)"$/
-  #           stream.send("#{k}=", v)
-  #         end
-  #       end
-  #     when :final
-  #       m3u.final_media_file = true
-  #     else
-  #       next
-  #     end
-  #   end
-  #   m3u
-  # end
+  def self.read(path)
+    m3u = self.new
+
+    lines = ::File.readlines(path)
+
+    lines.each_with_index do |line, i|
+      case type(line)
+      when :tag
+        name, value = parse_general_tag(line)
+        m3u.add_tag do |tag|
+          tag.name = name
+          tag.value = value
+        end
+      when :info
+        duration, description = parse_file_tag(line)
+        m3u.add_file do |file|
+          file.path = lines[i+1].strip
+          file.duration = duration
+          file.description = description
+        end
+        m3u.final_media_file = false
+      when :stream
+        attributes = parse_stream_tag(line)
+        m3u.add_stream do |stream|
+          stream.path = lines[i+1].strip
+          attributes.each_pair do |k,v|
+            k = k.to_s.downcase.sub('-','_')
+            next unless [:bandwidth, :program_id, :codecs, :resolution].include?(k)
+            v = $1 if v.to_s =~ /^"(.*)"$/
+            stream.send("#{k}=", v)
+          end
+        end
+      when :final
+        m3u.final_media_file = true
+      else
+        next
+      end
+    end
+
+    m3u
+  end
 
   def write_to_io(io_stream)
     reset_encryption_key_history

--- a/lib/m3uzi.rb
+++ b/lib/m3uzi.rb
@@ -301,37 +301,37 @@ class M3Uzi
 
 protected
 
-  # def self.type(line)
-  #   case line
-  #   when /^\s*$/
-  #     :whitespace
-  #   when /^#(?!EXT)/
-  #     :comment
-  #   when /^#EXTINF/
-  #     :info
-  #   when /^#EXT(-X)?-STREAM-INF/
-  #     :stream
-  #   when /^#EXT(-X)?-ENDLIST/
-  #     :final
-  #   when /^#EXT(?!INF)/
-  #     :tag
-  #   else
-  #     :file
-  #   end
-  # end
-  #
-  # def self.parse_general_tag(line)
-  #   line.match(/^#EXT(?:-X-)?(?!STREAM-INF)([^:\n]+)(:([^\n]+))?$/).values_at(1, 3)
-  # end
-  #
-  # def self.parse_file_tag(line)
-  #   line.match(/^#EXTINF:[ \t]*(\d+),?[ \t]*(.*)$/).values_at(1, 2)
-  # end
-  #
-  # def self.parse_stream_tag(line)
-  #   match = line.match(/^#EXT-X-STREAM-INF:(.*)$/)[1]
-  #   match.scan(/([A-Z-]+)\s*=\s*("[^"]*"|[^,]*)/) # return attributes as array of arrays
-  # end
+  def self.type(line)
+    case line
+    when /^\s*$/
+      :whitespace
+    when /^#(?!EXT)/
+      :comment
+    when /^#EXTINF/
+      :info
+    when /^#EXT(-X)?-STREAM-INF/
+      :stream
+    when /^#EXT(-X)?-ENDLIST/
+      :final
+    when /^#EXT(?!INF)/
+      :tag
+    else
+      :file
+    end
+  end
+
+  def self.parse_general_tag(line)
+    line.match(/^#EXT(?:-X-)?(?!STREAM-INF)([^:\n]+)(:([^\n]+))?$/).values_at(1, 3)
+  end
+
+  def self.parse_file_tag(line)
+    line.match(/^#EXTINF:[ \t]*(\d+),?[ \t]*(.*)$/).values_at(1, 2)
+  end
+
+  def self.parse_stream_tag(line)
+    match = line.match(/^#EXT-X-STREAM-INF:(.*)$/)[1]
+    match.scan(/([A-Z-]+)\s*=\s*("[^"]*"|[^,]*)/) # return attributes as array of arrays
+  end
 
   def cleanup_sliding_window
     return unless @sliding_window_duration && @playlist_type == :live

--- a/lib/m3uzi.rb
+++ b/lib/m3uzi.rb
@@ -57,7 +57,7 @@ class M3Uzi
         attributes = parse_stream_tag(line)
         m3u.add_stream do |stream|
           stream.path = lines[i+1].strip
-          attributes.each_pair do |k,v|
+          attributes.to_h.each do |k,v|
             k = k.to_s.downcase.sub('-','_')
             next unless [:bandwidth, :program_id, :codecs, :resolution].include?(k)
             v = $1 if v.to_s =~ /^"(.*)"$/


### PR DESCRIPTION
Why exactly was this functionality removed from `m3uzi` in the first place? I've been playing around with reading M3U8s using this gem and it's been working pretty well. Don't think I did much more than uncomment code and fix a couple syntax errors...
